### PR TITLE
Fix 1: don't truncate complex types with ...

### DIFF
--- a/index.spec.ts
+++ b/index.spec.ts
@@ -11,6 +11,7 @@ test("exports types", () => {
     "generic inferred function": "(x: string) => number",
     "generic inferred argument": "string",
     "generic inferred function custom": "(x: User) => string",
-    "generic inferred argument custom": "User"
+    "generic inferred argument custom": "User",
+    "deeply-nested": "{ \"problems\": { \"Diabetes\": { \"medications\": { \"medicationsClasses\": { \"className\": { \"associatedDrug\": { \"name\": string; \"dose\": string; \"strength\": string; }[]; \"associatedDrug#2\": { \"name\": string; \"dose\": string; \"strength\": string; }[]; }[]; \"className2\": { \"associatedDrug\": { \"name\": string; \"dose\": string; \"strength\": string; }[]; \"associatedDrug#2\": { \"name\": string; \"dose\": string; \"strength\": string; }[]; }[]; }[]; }[]; \"labs\": { \"missing_field\": string; }[]; }[]; \"Asthma\": {}[]; }[]; }",
   })
 });

--- a/index.ts
+++ b/index.ts
@@ -27,7 +27,9 @@ export function getTypes(filepath: string): Types {
     const exported = symbol.getJsDocTags().find(x => x.name === "export");
     if (!exported || !exported.text) return;
     exportedTypes[exported.text] = checker.typeToString(
-      checker.getTypeOfSymbolAtLocation(symbol, node)
+      checker.getTypeOfSymbolAtLocation(symbol, node),
+      undefined,
+      ts.TypeFormatFlags.NoTruncation
     );
   }
 }

--- a/test-file.ts
+++ b/test-file.ts
@@ -30,3 +30,30 @@ apply(
     /** @export generic inferred argument custom */ x
   ) => x.name
 );
+
+/** @export deeply-nested */
+const x = {
+  "problems": [{
+    "Diabetes": [{
+      "medications": [{
+        "medicationsClasses": [{
+          "className": [{
+            "associatedDrug":
+                [{"name": "asprin", "dose": "", "strength": "500 mg"}],
+            "associatedDrug#2":
+                [{"name": "somethingElse", "dose": "", "strength": "500 mg"}]
+          }],
+          "className2": [{
+            "associatedDrug":
+                [{"name": "asprin", "dose": "", "strength": "500 mg"}],
+            "associatedDrug#2":
+                [{"name": "somethingElse", "dose": "", "strength": "500 mg"}]
+          }]
+        }]
+      }],
+      "labs": [{"missing_field": "missing_value"}]
+    }],
+    "Asthma": [{}]
+  }]
+};
+// Via https://stackoverflow.com/q/10539797/500207


### PR DESCRIPTION
Use `ts.TypeFormatFlags.NoTruncation` flag to prevent truncation of complex types with ellipses. Includes test case.